### PR TITLE
drm_hwcomposer: Add optional gem caching mechanism for Imagination pl…

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -59,6 +59,7 @@ cc_defaults {
     cppflags: [
         "-DHWC2_USE_CPP11",
         "-DHWC2_INCLUDE_STRINGIFICATION",
+        "-DUSE_CLIENT_COMPOSITION",
     ],
 
     relative_install_path: "hw",

--- a/drmhwctwo.cpp
+++ b/drmhwctwo.cpp
@@ -903,6 +903,15 @@ HWC2::Error DrmHwcTwo::HwcDisplay::ValidateDisplay(uint32_t *num_types,
   *num_requests = 0;
   size_t avail_planes = primary_planes_.size() + overlay_planes_.size();
 
+#ifdef USE_CLIENT_COMPOSITION
+  (void) avail_planes;
+  for (std::pair<const hwc2_layer_t, DrmHwcTwo::HwcLayer> &l : layers_) {
+    l.second.set_validated_type(HWC2::Composition::Client );
+    ++*num_types;
+  }
+  return HWC2::Error::HasChanges;
+#else
+
   /*
    * If more layers then planes, save one plane
    * for client composited layers
@@ -978,6 +987,7 @@ HWC2::Error DrmHwcTwo::HwcDisplay::ValidateDisplay(uint32_t *num_types,
   total_stats_.total_pixops_ += total_pixops;
 
   return *num_types ? HWC2::Error::HasChanges : HWC2::Error::None;
+#endif
 }
 
 #if PLATFORM_SDK_VERSION > 28

--- a/drmhwctwo.cpp
+++ b/drmhwctwo.cpp
@@ -1186,6 +1186,7 @@ void DrmHwcTwo::DrmHotplugHandler::HandleEvent(uint64_t timestamp_us) {
     } else {
       auto &display = hwc2_->displays_.at(display_id);
       display.ClearDisplay();
+      hwc2_->resource_manager_.GetImporter(display_id)->HandleHotplug();
     }
 
     hwc2_->HandleDisplayHotplug(display_id, cur_state);

--- a/include/platform.h
+++ b/include/platform.h
@@ -55,6 +55,9 @@ class Importer {
 
   // Convert platform-dependent buffer format to drm_hwc internal format.
   virtual int ConvertBoInfo(buffer_handle_t handle, hwc_drm_bo_t *bo) = 0;
+
+  // Propagate display hotplug event to the platform part
+  virtual void HandleHotplug() = 0;
 };
 
 class Planner {

--- a/platform/platformdrmgeneric.h
+++ b/platform/platformdrmgeneric.h
@@ -46,6 +46,9 @@ class DrmGenericImporter : public Importer {
 
   int ConvertBoInfo(buffer_handle_t handle, hwc_drm_bo_t *bo) override;
 
+  void HandleHotplug() override {
+  }
+
   uint32_t ConvertHalFormatToDrm(uint32_t hal_format);
   uint32_t DrmFormatToBitsPerPixel(uint32_t drm_format);
 

--- a/platform/platformimagination.cpp
+++ b/platform/platformimagination.cpp
@@ -59,6 +59,77 @@ int ImaginationImporter::ConvertBoInfo(buffer_handle_t handle,
   return 0;
 }
 
+#ifdef ENABLE_GEM_HANDLE_CACHING
+ImaginationImporter::~ImaginationImporter() {
+  std::lock_guard<std::mutex> lock(cachedBoMutex_);
+  for (auto &pair : cachedBo_) {
+    DrmGenericImporter::ReleaseBuffer(&pair.second.bo);
+  }
+  cachedBo_.clear();
+}
+
+int ImaginationImporter::ImportBuffer(buffer_handle_t ghandle,
+                                      hwc_drm_bo_t *bo) {
+  IMG_native_handle_t *img_hnd = (IMG_native_handle_t *)ghandle;
+  int ret = 0;
+
+  if (!img_hnd)
+    return -EINVAL;
+
+  {
+    std::lock_guard<std::mutex> lock(cachedBoMutex_);
+    auto it = cachedBo_.find(img_hnd->ui64Stamp);
+    if (it != cachedBo_.end()) {
+      it->second.used = true;
+      *bo = it->second.bo;
+      return 0;
+    }
+  }
+  ret = DrmGenericImporter::ImportBuffer(ghandle, bo);
+  if (ret) {
+    ALOGE("could not create drm fb %d", ret);
+    return ret;
+  }
+  {
+    std::lock_guard<std::mutex> lock(cachedBoMutex_);
+
+    bo->priv = reinterpret_cast<void *>(img_hnd->ui64Stamp);
+    bo_t buffer;
+    buffer.bo = *bo;
+    buffer.needFlush = false;
+    buffer.used = true;
+
+    cachedBo_.insert(std::make_pair(img_hnd->ui64Stamp, buffer));
+  }
+  return ret;
+}
+
+int ImaginationImporter::ReleaseBuffer(hwc_drm_bo_t *bo) {
+  std::lock_guard<std::mutex> lock(cachedBoMutex_);
+  unsigned long long key = reinterpret_cast<unsigned long long>(bo->priv);
+  auto &buffer = cachedBo_[key];
+  buffer.used = false;
+  if (buffer.needFlush) {
+    DrmGenericImporter::ReleaseBuffer(&buffer.bo);
+    buffer.needFlush = false;
+    cachedBo_.erase(key);
+  }
+  return 0;
+}
+void ImaginationImporter::HandleHotplug() {
+  std::lock_guard<std::mutex> lock(cachedBoMutex_);
+  for (auto it = cachedBo_.begin(); it != cachedBo_.end();) {
+    it->second.needFlush = true;
+    if (!it->second.used) {
+      DrmGenericImporter::ReleaseBuffer(&it->second.bo);
+      it = cachedBo_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+#endif
+
 std::unique_ptr<Planner> Planner::CreateInstance(DrmDevice *) {
   std::unique_ptr<Planner> planner(new Planner);
   planner->AddStage<PlanStageGreedy>();

--- a/platform/platformimagination.h
+++ b/platform/platformimagination.h
@@ -16,6 +16,25 @@ class ImaginationImporter : public DrmGenericImporter {
   using DrmGenericImporter::DrmGenericImporter;
 
   int ConvertBoInfo(buffer_handle_t handle, hwc_drm_bo_t *bo) override;
+
+#ifdef ENABLE_GEM_HANDLE_CACHING
+  typedef struct bo_cached_descriptor {
+    hwc_drm_bo_t bo;
+    // Handle used by some external component(SF)
+    bool used;
+    // Deallocation needed
+    bool needFlush;
+  } bo_t;
+
+  ~ImaginationImporter() override;
+  int ImportBuffer(buffer_handle_t handle, hwc_drm_bo_t *bo) override;
+  int ReleaseBuffer(hwc_drm_bo_t *bo) override;
+  void HandleHotplug() override;
+
+ private:
+  std::map<unsigned long long, bo_t> cachedBo_;
+  std::mutex cachedBoMutex_;
+#endif
 };
 }  // namespace android
 


### PR DESCRIPTION
…atform

On some platform[1] frequent calls of the drmPrimeFDToHandle/drmModeAddFB2
may cause tremendous performance degradation. In case, if DRM driver[2] has
only a primary plane(i.e. all composition done by OpenGL) there is no
practical sense to import/release the same render targets per each frame.
This patch utilizes specific Imagination field ui64Stamp of
the IMG_native_handle_t to clearly identify buffer on which native
handle points. Display hotplug event handling is needed to deallocate
all handles/gem connected with a display.

1. Considering hypervisor-based guest domain, using drm [2] driver.
2. https://elixir.bootlin.com/linux/v5.0/source/drivers/gpu/drm/xen

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>